### PR TITLE
PR for releasea v1.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,21 +27,21 @@ Arch (or Arch based distro) users can install the [malias](https://aur.archlinux
 
 Launch the following command in your terminal to execute the install script (requires "curl" and "sudo") :
 ```
-curl -s https://raw.githubusercontent.com/Antiz96/Malias/main/install.sh | bash
+curl -s https://raw.githubusercontent.com/Antiz96/malias/main/install.sh | bash
 ```
 
 #### Update
 
 Simply re-execute the install script (requires "curl" and "sudo") :
 ```
-curl -s https://raw.githubusercontent.com/Antiz96/Malias/main/install.sh | bash
+curl -s https://raw.githubusercontent.com/Antiz96/malias/main/install.sh | bash
 ```
 
 #### Uninstalling
 
 Launch the following command in your terminal to execute the uninstall script :
 ```
-curl -s https://raw.githubusercontent.com/Antiz96/Malias/main/uninstall.sh | bash
+curl -s https://raw.githubusercontent.com/Antiz96/malias/main/uninstall.sh | bash
 ```
 
 ## Usage

--- a/install.sh
+++ b/install.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 pkgname="malias"
-url="https://github.com/Antiz96/Malias"
-latest_release=$(curl -s https://raw.githubusercontent.com/Antiz96/Malias/main/latest_release.txt)
+url="https://github.com/Antiz96/malias"
+latest_release=$(curl -s https://raw.githubusercontent.com/Antiz96/malias/main/latest_release.txt)
 
 checksum=$(curl -Ls "$url"/releases/download/v"$latest_release"/sha256sum.txt)
 installed=$(command -v "$pkgname")

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -1,12 +1,11 @@
 #!/bin/bash
 
-pkgname="Malias"
-_pkgname="malias"
-url="https://github.com/Antiz96/Malias"
+pkgname="malias"
+url="https://github.com/Antiz96/malias"
 
 echo -e "$pkgname is going to be uninstalled\n"
 
-sudo rm -f /usr/local/bin/"$_pkgname" || exit 1
-sudo rm -f /usr/local/share/man/man1/"$_pkgname".1.gz || exit 1
+sudo rm -f /usr/local/bin/"$pkgname" || exit 1
+sudo rm -f /usr/local/share/man/man1/"$pkgname".1.gz || exit 1
 
 echo -e "$pkgname has been successfully uninstalled\nPlease, visit $url for more information"


### PR DESCRIPTION
Pull request for release v1.2.0

- new -v option (print the current version)
- new install and uninstall script
- Message that relates to error now printed in the error output (2)
- Man page is not "pre-zipped" anymore
- New dev branch
- New repo structure
- Now following semantic versioning principles
- Various little changes here and there

