### PR TITLE
Use separated exit codes for each type of errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,9 +101,16 @@ Options:
   -d, --delete   Delete an existing alias  
   -h, --help     Display this message and exit  
   -V, --version  Display version information and exit  
+
+Exit Codes:
+  0  OK
+  1  Invalid argument/option
+  2  User didn't gave the confirmation to proceed
+  3  An error occured when creating/restoring the backup of the .bashrc file
+  4  An error occured when adding/removing the alias
+```
   
 For more information, see the malias(1) man page
-```
 
 ## Contributing
 

--- a/doc/man/malias.1
+++ b/doc/man/malias.1
@@ -39,14 +39,26 @@ Print the current version.
 .B \-h, \-\-help
 Print the help.
 
-.SH EXIT STATUS
+.SH EXIT CODES
 .TP
 .B 0
-if OK
+OK
 
 .TP
 .B 1
-if problems (user didn't gave confirmation to proceed with the adding/deletion, a problem happened during the backup/restore process of the .bashrc file, the added alias is incorrect, ...)
+Invalid argument/option
+
+.TP
+.B 2
+User didn't gave the confirmation to proceed
+
+.TP
+.B 3
+An error occured when creating/restoring the backup of the .bashrc file
+
+.TP
+.B 4
+An error occured when adding/removing the alias
 
 .SH USAGE
 .TP

--- a/src/script/malias.sh
+++ b/src/script/malias.sh
@@ -102,7 +102,13 @@ add() {
 		;;
 	esac
 
-	cp -p ~/.bashrc ~/.bashrc-bck_${name}-add-"${alias_name}"-"$(date +"%d-%m-%Y")" && echo -e "\nBackup of the .bashrc file created" || { echo -e >&2 "ERROR: An error occured when creating the backup of the .bashrc file"; exit 3; }
+	if cp -p ~/.bashrc ~/.bashrc-bck_${name}-add-"${alias_name}"-"$(date +"%d-%m-%Y")"; then
+		echo -e "\nBackup of the .bashrc file created"
+	else
+		echo -e >&2 "ERROR: An error occured when creating the backup of the .bashrc file"
+		exit 3
+	fi
+
 	echo "alias ${new_alias}" >> ~/.bashrc
 
 	source_error=$(bash -x ~/.bashrc 2>/dev/null; echo $?)
@@ -113,7 +119,12 @@ add() {
 		exec bash
 	else
 		echo -e >&2 "\nERROR: An error occured when adding the alias\nPlease verify that you typed the alias correctly\nAlso, be aware that the alias name cannot contain space(s). However, it can contain \"-\" (hyphen) or \"_\" (underscore)"
-		mv -f ~/.bashrc-bck_${name}-add-"${alias_name}"-"$(date +"%d-%m-%Y")" ~/.bashrc && echo "Backup of the .bashrc file restored" || { echo -e >&2 "\nERROR: An error occurred when restoring the backup of the ~/.bashrc file\nPlease, check for potential errors in it"; exit 3; }
+		if mv -f ~/.bashrc-bck_${name}-add-"${alias_name}"-"$(date +"%d-%m-%Y")" ~/.bashrc; then
+			echo "Backup of the .bashrc file restored"
+		else
+			echo -e >&2 "\nERROR: An error occurred when restoring the backup of the ~/.bashrc file\nPlease, check for potential errors in it"
+			exit 3
+		fi
 		exit 4
 	fi
 }
@@ -154,7 +165,12 @@ delete() {
 			;;
 		esac
 
-		cp -p ~/.bashrc ~/.bashrc-bck_${name}-delete-"${alias_name}"-"$(date +"%d-%m-%Y")" && echo -e "\nBackup of the .bashrc file created" || { echo -e >&2 "ERROR: An error occured when creating the backup of the .bashrc file"; exit 3; }
+		if cp -p ~/.bashrc ~/.bashrc-bck_${name}-delete-"${alias_name}"-"$(date +"%d-%m-%Y")"; then
+			echo -e "\nBackup of the .bashrc file created"
+		else
+			echo -e >&2 "ERROR: An error occured when creating the backup of the .bashrc file"
+			exit 3
+		fi
 
 		sed -i "/^alias ${alias_delete}$/d" ~/.bashrc
 
@@ -166,7 +182,12 @@ delete() {
 			exec bash
 		else
 			echo -e >&2 "\nERROR: An error occured when deleting the alias"
-			mv -f ~/.bashrc-bck_${name}-delete-"${alias_name}"-"$(date +"%d-%m-%Y")" ~/.bashrc && echo "Backup of the .bashrc file restored" || { echo -e >&2 "\nERROR: An error occurred when restoring the backup of the ~/.bashrc file\nPlease, check for potential errors in it"; exit 3; }
+			if mv -f ~/.bashrc-bck_${name}-delete-"${alias_name}"-"$(date +"%d-%m-%Y")" ~/.bashrc; then
+				echo "Backup of the .bashrc file restored"
+			else
+				echo -e >&2 "\nERROR: An error occurred when restoring the backup of the ~/.bashrc file\nPlease, check for potential errors in it"
+				exit 3
+			fi
 			exit 4
 		fi
 	else


### PR DESCRIPTION
This PR aims to make use of separated exit codes for each type of errors in order to simplify potential debugging.