### PR TITLE
Use complete version ref in man page

### DIFF
--- a/doc/man/malias.1
+++ b/doc/man/malias.1
@@ -1,4 +1,4 @@
-.TH "MALIAS" "1" "June 2023" "Malias v1" "Malias Manual"
+.TH "MALIAS" "1" "June 2023" "Malias 1.2.5" "Malias Manual"
 
 .SH NAME
 malias \- An alias manager that allows you to easily add, delete or list your bash aliases.


### PR DESCRIPTION
It feels clearer to have the actual complete version reference in the man page, specifically when options/features are added or remove.